### PR TITLE
BlockhashExample - blockhash

### DIFF
--- a/contracts/examples/Blockhash.sol
+++ b/contracts/examples/Blockhash.sol
@@ -26,7 +26,7 @@ contract BlockhashExample is ERC721, BatchReveal {
             _mint(msg.sender, totalSupply);
             totalSupply++;
             if(totalSupply >= (lastTokenRevealed + REVEAL_BATCH_SIZE)){
-                setBatchSeed(uint256(blockhash(block.number)));
+                setBatchSeed(uint256(blockhash(block.number-1)));
             }
         }
     }


### PR DESCRIPTION
blockhash(block.number) is always 0. Last block's blockhash will be valid data
https://github.com/ethereum/go-ethereum/blob/b1e72f7ea998ad662166bcf23705ca59cf81e925/core/vm/instructions.go#L449